### PR TITLE
Define app json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "Dajare Server",
+  "website": "https://dajare.herokuapp.com",
+  "repository": "https://github.com/satoryu/dajare",
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "Standard-1X"
+    }
+  },
+  "env": {
+    "HIPCHAT_AVATAR_URL": {
+      "description": "The url of the avatar appearing in HipChat",
+      "required": true
+    }
+  }
+}

--- a/app.rb
+++ b/app.rb
@@ -31,7 +31,7 @@ class Dajare < Sinatra::Base
         capabilities: {
           hipchatApiConsumer: {
             avatar: {
-              url: 'http://event.shoeisha.jp/static/images/speaker/954/18d1_mr_kawaguchi.png'
+              url: ENV['HIPCHAT_AVATAR_URL']
             },
             scopes: %w[send_message view_messages]
           },


### PR DESCRIPTION
I'd like to use heroku's feature [Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps). It requires this app to have [app.json](devcenter.heroku.com/articles/app-json-schema). 

This PR provides the one for this app. 
